### PR TITLE
mkbootimg: only include m8 dts

### DIFF
--- a/mkbootimg.mk
+++ b/mkbootimg.mk
@@ -8,8 +8,7 @@ PERL = perl
 ## Imported from the original makefile...
 KERNEL_CONFIG := $(KERNEL_OUT)/.config
 
-M8_DTS_NAMES ?= $(shell $(PERL) -e 'while (<>) {$$a = $$1 if /CONFIG_ARCH_((?:MSM|QSD|MPQ)[a-zA-Z0-9]+)=y/; $$r = $$1 if /CONFIG_MSM_SOC_REV_(?!NONE)(\w+)=y/; $$arch = $$arch.lc("$$a$$r ") if /CONFIG_ARCH_((?:MSM|QSD|MPQ)[a-zA-Z0-9]+)=y/} print $$arch;' $(KERNEL_CONFIG))
-M8_DTS_FILES = $(wildcard $(TOP)/$(TARGET_KERNEL_SOURCE)/arch/arm/boot/dts/$(M8_DTS_NAME)*.dts)
+M8_DTS_FILES = $(wildcard $(TOP)/$(TARGET_KERNEL_SOURCE)/arch/arm/boot/dts/msm8974pro-ab-pm8941-m8*.dts)
 M8_DTS_FILE = $(lastword $(subst /, ,$(1)))
 DTB_FILE = $(addprefix $(KERNEL_OUT)/arch/arm/boot/,$(patsubst %.dts,%.dtb,$(call M8_DTS_FILE,$(1))))
 ZIMG_FILE = $(addprefix $(KERNEL_OUT)/arch/arm/boot/,$(patsubst %.dts,%-zImage,$(call M8_DTS_FILE,$(1))))
@@ -18,12 +17,10 @@ DTC = $(KERNEL_OUT)/scripts/dtc/dtc
 DTBTAGNAME := "htc,project-id = <"
 
 define append-m8-dtb
-$(foreach M8_DTS_NAME, $(M8_DTS_NAMES), \
+   mkdir -p $(KERNEL_OUT)/arch/arm/boot;\
    $(foreach d, $(M8_DTS_FILES), \
-      $(DTC) -p 1024 -O dtb -o $(call DTB_FILE,$(d)) $(d); \
-      cat $(KERNEL_ZIMG) $(call DTB_FILE,$(d)) > $(call ZIMG_FILE,$(d));))
+      cat $(KERNEL_ZIMG) $(call DTB_FILE,$(d)) > $(call ZIMG_FILE,$(d));)
 endef
-
 
 ## Build and run dtbtool
 DTBTOOL := $(HOST_OUT_EXECUTABLES)/dtbToolCM$(HOST_EXECUTABLE_SUFFIX)


### PR DESCRIPTION
* saves over 1.5mb in dt.img size

Change-Id: I1ef243304e0de9512129d8b2005b9c15b361f06b